### PR TITLE
Fix range highlight to treat right column as inclusive

### DIFF
--- a/src/client/fsharp/FSharpTokens/State.fs
+++ b/src/client/fsharp/FSharpTokens/State.fs
@@ -149,7 +149,7 @@ let update code msg model =
                         { StartLine = activeLine
                           StartColumn = token.LeftColumn
                           EndLine = activeLine
-                          EndColumn = token.RightColumn }
+                          EndColumn = token.RightColumn + 1 }
 
                     Cmd.ofSub (Editor.selectRange range))
             |> Option.defaultValue Cmd.none


### PR DESCRIPTION
This PR fixes the Tokens view so that the highlighted range accurately reflects the selected token. The `TokenInfo.RightColumn` is inclusive, but the `EndColumn` set in the view is exclusive, so assigning RightColumn` does not highlight the final character in the token (which is particularly confusing for single character tokens).

Before:

https://user-images.githubusercontent.com/1901832/128615600-b2518d81-ed6a-4dda-bca7-76d10928c605.mp4

After:

https://user-images.githubusercontent.com/1901832/128615607-baee345f-5f1b-426b-9d27-ff4f311150b4.mp4

