### PR TITLE
Update copied message to `.editorconfig` instead of `fantomas-config`

### DIFF
--- a/src/client/fsharp/FantomasOnline/State.fs
+++ b/src/client/fsharp/FantomasOnline/State.fs
@@ -184,7 +184,7 @@ let private copySettings (model: Model) _ =
     |> Promise.catch (fun err ->
         showError "Something went wrong while copying settings to the clipboard."
         printfn "%A" err)
-    |> Promise.iter (fun () -> showSuccess "Copied fantomas-config settings to clipboard!")
+    |> Promise.iter (fun () -> showSuccess "Copied .editorconfg settings to clipboard!")
 
 let update isActiveTab code msg model =
     match msg with


### PR DESCRIPTION
Quick PR to update the dialog, I copied a small configuration via the fantomas-tool hoping it would copy `.editorconfig`, not the older `fantomas-config.json`, so I was confused when by the message.