### PR TITLE
Add ruler to editor on the current max_line_length setting.

### DIFF
--- a/src/client/fsharp/Editor.fs
+++ b/src/client/fsharp/Editor.fs
@@ -22,16 +22,8 @@ type MonacoEditorProp =
     | OnMount of Action<IMonacoEditor, obj>
     | Options of obj
 
-    static member rulerOption userOptions defaultOptions =
-        let maxLineLength =
-            FantomasOnline.Shared.tryGetOptionValue userOptions defaultOptions "MaxLineLength" int
-
-        match maxLineLength with
-        | Some n ->
-            createObj
-                [ "rulers"
-                  ==> [| createObj [ "column" ==> n; "color" ==> "black" ] |] ]
-        | None -> createObj []
+    static member rulerOption column =
+        {| rulers = [| {| column = column; color = "#2FBADC" |} |] |} :> obj
 
 let inline private MonacoEditor (props: MonacoEditorProp list) : ReactElement =
     ofImport "default" "@monaco-editor/react" (keyValueList CaseRules.LowerFirst props) []

--- a/src/client/fsharp/Editor.fs
+++ b/src/client/fsharp/Editor.fs
@@ -22,6 +22,17 @@ type MonacoEditorProp =
     | OnMount of Action<IMonacoEditor, obj>
     | Options of obj
 
+    static member rulerOption userOptions defaultOptions =
+        let maxLineLength =
+            FantomasOnline.Shared.tryGetOptionValue userOptions defaultOptions "MaxLineLength" int
+
+        match maxLineLength with
+        | Some n ->
+            createObj
+                [ "rulers"
+                  ==> [| createObj [ "column" ==> n; "color" ==> "black" ] |] ]
+        | None -> createObj []
+
 let inline private MonacoEditor (props: MonacoEditorProp list) : ReactElement =
     ofImport "default" "@monaco-editor/react" (keyValueList CaseRules.LowerFirst props) []
 

--- a/src/client/fsharp/FantomasOnline/Model.fs
+++ b/src/client/fsharp/FantomasOnline/Model.fs
@@ -46,3 +46,7 @@ type Model =
         List.zip defaultValues userValues
         |> List.filter (fun (dv, uv) -> dv <> uv)
         |> List.map snd
+
+    member this.MaxLineLength: int =
+        FantomasOnline.Shared.tryGetOptionValue this.UserOptions this.DefaultOptions "MaxLineLength" int
+        |> Option.defaultValue 120

--- a/src/client/fsharp/FantomasOnline/View.fs
+++ b/src/client/fsharp/FantomasOnline/View.fs
@@ -316,7 +316,7 @@ let view model =
             ] [
                 Editor true [
                     MonacoEditorProp.DefaultValue formattedCode
-                    MonacoEditorProp.Options(MonacoEditorProp.rulerOption model.UserOptions model.DefaultOptions)
+                    MonacoEditorProp.Options(MonacoEditorProp.rulerOption model.MaxLineLength)
                 ]
             ]
             ofOption (viewErrors model result isIdempotent astErrors)

--- a/src/client/fsharp/FantomasOnline/View.fs
+++ b/src/client/fsharp/FantomasOnline/View.fs
@@ -316,6 +316,7 @@ let view model =
             ] [
                 Editor true [
                     MonacoEditorProp.DefaultValue formattedCode
+                    MonacoEditorProp.Options(MonacoEditorProp.rulerOption model.UserOptions model.DefaultOptions)
                 ]
             ]
             ofOption (viewErrors model result isIdempotent astErrors)

--- a/src/client/fsharp/View.fs
+++ b/src/client/fsharp/View.fs
@@ -91,6 +91,9 @@ let editor model dispatch =
             Editor false [
                 MonacoEditorProp.OnChange(UpdateSourceCode >> dispatch)
                 MonacoEditorProp.DefaultValue model.SourceCode
+                MonacoEditorProp.Options(
+                    MonacoEditorProp.rulerOption model.FantomasModel.UserOptions model.FantomasModel.DefaultOptions
+                )
             ]
         ]
     ]

--- a/src/client/fsharp/View.fs
+++ b/src/client/fsharp/View.fs
@@ -91,9 +91,7 @@ let editor model dispatch =
             Editor false [
                 MonacoEditorProp.OnChange(UpdateSourceCode >> dispatch)
                 MonacoEditorProp.DefaultValue model.SourceCode
-                MonacoEditorProp.Options(
-                    MonacoEditorProp.rulerOption model.FantomasModel.UserOptions model.FantomasModel.DefaultOptions
-                )
+                MonacoEditorProp.Options(MonacoEditorProp.rulerOption model.FantomasModel.MaxLineLength)
             ]
         ]
     ]

--- a/src/shared/FantomasOnlineShared.fs
+++ b/src/shared/FantomasOnlineShared.fs
@@ -27,6 +27,23 @@ let optionValue =
     | MultilineFormatterTypeOption (_, _, v)
     | EndOfLineStyleOption (_, _, v) -> v
 
+let tryGetUserOptionValue userOptions key castFunc =
+    userOptions
+    |> Map.tryFind key
+    |> Option.map (optionValue >> castFunc)
+
+let tryGetDefaultOptionValue defaultOptions key castFunc =
+    defaultOptions
+    |> List.tryFind (fun o -> (getOptionKey o) = key)
+    |> Option.map (optionValue >> castFunc)
+
+let tryGetOptionValue userOptions defaultOptions key castFunc =
+    let userOption = tryGetUserOptionValue userOptions key castFunc
+
+    match userOption with
+    | Some n -> Some n
+    | None -> tryGetDefaultOptionValue defaultOptions key castFunc
+
 type FormatRequest =
     { SourceCode: string
       Options: FantomasOption list


### PR DESCRIPTION
Fixes #391 

Not super sure about the placement of the code.
Depending on your screen resolution you might need to lower the max_line_length setting to bring the ruler into view.