### PR TITLE
Improve Oak view hover

### DIFF
--- a/src/client/src/styles/oak.sass
+++ b/src/client/src/styles/oak.sass
@@ -8,14 +8,14 @@
   max-height: 100%
   
   > div
-    margin: 1px 0
+    margin: 1px
     padding: 0
     line-height: 1rem
     transition: all 0.4s
     
     &:hover
       cursor: pointer
-      border: 1px solid $dark
+      outline: 1px solid $dark
 
     & .highlight
       color: $white


### PR DESCRIPTION
Border on hover causes a lot of disorienting flicker, because it displaces content below by 2px. `outline` otoh does not affect box size.