### PR TITLE
Add button to import settings from .editorconfig file

### DIFF
--- a/fantomas-tools.sln
+++ b/fantomas-tools.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -36,6 +36,16 @@ EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FantomasOnlinePreview", "src\server\FantomasOnlinePreview\FantomasOnlinePreview.fsproj", "{1FD7B2E9-A132-4DC0-89D0-4DE78713488E}"
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FantomasOnlineV6", "src\server\FantomasOnlineV6\FantomasOnlineV6.fsproj", "{2F8EF5DD-8003-4911-B90A-0BFB970DA1C2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A76D9559-8637-413C-9109-677EC3D63578}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		build.fsx = build.fsx
+		Directory.Build.props = Directory.Build.props
+		global.json = global.json
+		README.md = README.md
+		.config\dotnet-tools.json = .config\dotnet-tools.json
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/client/fsharp/FantomasOnline/Decoders.fs
+++ b/src/client/fsharp/FantomasOnline/Decoders.fs
@@ -34,83 +34,69 @@ let decodeOptions json =
 let decodeOptionsFromUrl: Decoder<FantomasOption list> =
     Decode.object (fun get -> get.Required.Field "settings" (Decode.list optionDecoder))
 
-let decodeOptionsFromEditorConfigFile (currentSettings: Map<string, FantomasOption>) (fileText: string) =
-    fileText.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries)
-    |> Array.filter (fun line -> line.StartsWith("fsharp_", StringComparison.OrdinalIgnoreCase))
-    |> Array.map (fun line ->
-        let parts =
-            line.Split([| '='; ' ' |], StringSplitOptions.RemoveEmptyEntries)
-            |> Array.toList
+let rec decodeEditorConfigLine (currentSettings: Map<string, FantomasOption>) i (line: string) =
+    let parts =
+        line.Split([| '='; ' ' |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.toList
 
-        let toPascalCase (str: string) =
-            let rec buildStr acc (split: string list) =
-                match split with
-                | [] -> acc
-                | h :: t ->
-                    let first = h[0] |> Char.ToUpper |> string
-                    buildStr (acc + first + h[1..]) t
+    let toPascalCase (str: string) =
+        let rec buildStr acc (split: string list) =
+            match split with
+            | [] -> acc
+            | h :: t ->
+                let first = h[0] |> Char.ToUpper |> string
+                buildStr (acc + first + h[1..]) t
 
-            str.Split([| '_' |], StringSplitOptions.RemoveEmptyEntries)
-            |> Array.toList
-            |> buildStr ""
+        str.Split([| '_' |], StringSplitOptions.RemoveEmptyEntries)
+        |> Array.toList
+        |> buildStr ""
 
-        match parts with
-        | name :: value :: _ ->
-            let name = name.Trim().Replace("fsharp_", "")
-            let value = value.Trim()
-            let isInt, intValue = Int32.TryParse value
-            let isBool, boolValue = Boolean.TryParse value
+    match parts with
+    | name :: value :: _ ->
+        let name = name.Trim().Replace("fsharp_", "")
+        let value = value.Trim()
+        let isInt, intValue = Int32.TryParse value
+        let isBool, boolValue = Boolean.TryParse value
 
-            let pascalName = toPascalCase name
-            let existing = currentSettings.TryFind pascalName
+        let pascalName = toPascalCase name
+        let existing = currentSettings.TryFind pascalName
 
+        let optionValue =
             match existing with
             | Some(FantomasOption.IntOption(order, pascalName, _)) when isInt ->
-                pascalName, FantomasOption.IntOption(order, pascalName, intValue)
+                FantomasOption.IntOption(order, pascalName, intValue)
             | Some(FantomasOption.BoolOption(order, pascalName, _)) when isBool ->
-                pascalName, FantomasOption.BoolOption(order, pascalName, boolValue)
+                FantomasOption.BoolOption(order, pascalName, boolValue)
             | Some(FantomasOption.MultilineFormatterTypeOption(order, pascalName, _)) ->
-                pascalName, FantomasOption.MultilineFormatterTypeOption(order, pascalName, value)
+                FantomasOption.MultilineFormatterTypeOption(order, pascalName, value)
             | Some(FantomasOption.EndOfLineStyleOption(order, pascalName, _)) ->
-                pascalName, FantomasOption.EndOfLineStyleOption(order, pascalName, value)
+                FantomasOption.EndOfLineStyleOption(order, pascalName, value)
             | Some(FantomasOption.MultilineBracketStyleOption(order, pascalName, _)) ->
-               pascalName, FantomasOption.MultilineBracketStyleOption(order, pascalName, value)
-            | _ -> failwithf $"Cannot decode `{line}`"
-        //
-        // match name with
-        // | _ when isInt -> FantomasOption.IntOption(i, pascalName, intValue)
-        // | _ when isBool -> FantomasOption.BoolOption(i, pascalName, boolValue)
-        // | "record_multiline_formatter"
-        // | "array_or_list_multiline_formatter" -> FantomasOption.MultilineFormatterTypeOption(i, pascalName, value)
-        // | "end_of_line" -> FantomasOption.EndOfLineStyleOption(i, pascalName, value)
-        // | "multiline_bracket_style" -> FantomasOption.MultilineBracketStyleOption(i, pascalName, value)
-        // | name -> failwithf $"Cannot decode %s{name}"
-        | _ -> failwithf $"Cannot decode `{line}`")
+                FantomasOption.MultilineBracketStyleOption(order, pascalName, value)
+            | _ ->
+                let pascalName = toPascalCase name
+
+                match name with
+                | _ when isInt -> FantomasOption.IntOption(i, pascalName, intValue)
+                | _ when isBool -> FantomasOption.BoolOption(i, pascalName, boolValue)
+                | "record_multiline_formatter"
+                | "array_or_list_multiline_formatter" ->
+                    FantomasOption.MultilineFormatterTypeOption(i, pascalName, value)
+                | "end_of_line" -> FantomasOption.EndOfLineStyleOption(i, pascalName, value)
+                | "multiline_bracket_style" -> FantomasOption.MultilineBracketStyleOption(i, pascalName, value)
+                | name -> failwithf $"Cannot decode %s{name}"
+
+        pascalName, optionValue
+    | _ -> failwithf $"Cannot decode `{line}`"
+
+let decodeOptionsFromEditorConfigFile (currentSettings: Map<string, FantomasOption>) (fileText: string) =
+    fileText.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.filter (fun line ->
+        line.StartsWith("fsharp_", StringComparison.OrdinalIgnoreCase)
+        || [ "max_line_length"; "indent_size"; "end_of_line"; "insert_final_newline" ]
+           |> List.exists (fun prop -> line.StartsWith(prop, StringComparison.OrdinalIgnoreCase)))
+    |> Array.mapi (decodeEditorConfigLine currentSettings)
     |> Array.toList
-
-let private decodeRange: Decoder<Range> =
-    Decode.object (fun get ->
-        { StartLine = get.Required.Field "startLine" Decode.int
-          StartCol = get.Required.Field "startCol" Decode.int
-          EndLine = get.Required.Field "endLine" Decode.int
-          EndCol = get.Required.Field "endCol" Decode.int })
-
-let private decoderASTErrorSeverity: Decoder<ASTErrorSeverity> =
-    Decode.string
-    |> Decode.map (fun s ->
-        match s with
-        | "error" -> ASTErrorSeverity.Error
-        | "warning" -> ASTErrorSeverity.Warning
-        | "info" -> ASTErrorSeverity.Info
-        | _ -> ASTErrorSeverity.Hidden)
-
-let private decodeASTError: Decoder<ASTError> =
-    Decode.object (fun get ->
-        { SubCategory = get.Required.Field "subCategory" Decode.string
-          Range = get.Required.Field "range" decodeRange
-          Severity = get.Required.Field "severity" decoderASTErrorSeverity
-          ErrorNumber = get.Required.Field "errorNumber" Decode.int
-          Message = get.Required.Field "message" Decode.string })
 
 let decodeFormatResponse: Decoder<FormatResponse> =
     Decode.object (fun get ->

--- a/src/client/fsharp/FantomasOnline/Decoders.fs
+++ b/src/client/fsharp/FantomasOnline/Decoders.fs
@@ -1,5 +1,6 @@
 module FantomasTools.Client.FantomasOnline.Decoders
 
+open System
 open FantomasTools.Client
 open Thoth.Json
 open FantomasOnline.Shared
@@ -32,6 +33,84 @@ let decodeOptions json =
 
 let decodeOptionsFromUrl: Decoder<FantomasOption list> =
     Decode.object (fun get -> get.Required.Field "settings" (Decode.list optionDecoder))
+
+let decodeOptionsFromEditorConfigFile (currentSettings: Map<string, FantomasOption>) (fileText: string) =
+    fileText.Split([| Environment.NewLine |], StringSplitOptions.RemoveEmptyEntries)
+    |> Array.filter (fun line -> line.StartsWith("fsharp_", StringComparison.OrdinalIgnoreCase))
+    |> Array.map (fun line ->
+        let parts =
+            line.Split([| '='; ' ' |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.toList
+
+        let toPascalCase (str: string) =
+            let rec buildStr acc (split: string list) =
+                match split with
+                | [] -> acc
+                | h :: t ->
+                    let first = h[0] |> Char.ToUpper |> string
+                    buildStr (acc + first + h[1..]) t
+
+            str.Split([| '_' |], StringSplitOptions.RemoveEmptyEntries)
+            |> Array.toList
+            |> buildStr ""
+
+        match parts with
+        | name :: value :: _ ->
+            let name = name.Trim().Replace("fsharp_", "")
+            let value = value.Trim()
+            let isInt, intValue = Int32.TryParse value
+            let isBool, boolValue = Boolean.TryParse value
+
+            let pascalName = toPascalCase name
+            let existing = currentSettings.TryFind pascalName
+
+            match existing with
+            | Some(FantomasOption.IntOption(order, pascalName, _)) when isInt ->
+                pascalName, FantomasOption.IntOption(order, pascalName, intValue)
+            | Some(FantomasOption.BoolOption(order, pascalName, _)) when isBool ->
+                pascalName, FantomasOption.BoolOption(order, pascalName, boolValue)
+            | Some(FantomasOption.MultilineFormatterTypeOption(order, pascalName, _)) ->
+                pascalName, FantomasOption.MultilineFormatterTypeOption(order, pascalName, value)
+            | Some(FantomasOption.EndOfLineStyleOption(order, pascalName, _)) ->
+                pascalName, FantomasOption.EndOfLineStyleOption(order, pascalName, value)
+            | Some(FantomasOption.MultilineBracketStyleOption(order, pascalName, _)) ->
+               pascalName, FantomasOption.MultilineBracketStyleOption(order, pascalName, value)
+            | _ -> failwithf $"Cannot decode `{line}`"
+        //
+        // match name with
+        // | _ when isInt -> FantomasOption.IntOption(i, pascalName, intValue)
+        // | _ when isBool -> FantomasOption.BoolOption(i, pascalName, boolValue)
+        // | "record_multiline_formatter"
+        // | "array_or_list_multiline_formatter" -> FantomasOption.MultilineFormatterTypeOption(i, pascalName, value)
+        // | "end_of_line" -> FantomasOption.EndOfLineStyleOption(i, pascalName, value)
+        // | "multiline_bracket_style" -> FantomasOption.MultilineBracketStyleOption(i, pascalName, value)
+        // | name -> failwithf $"Cannot decode %s{name}"
+        | _ -> failwithf $"Cannot decode `{line}`")
+    |> Array.toList
+
+let private decodeRange: Decoder<Range> =
+    Decode.object (fun get ->
+        { StartLine = get.Required.Field "startLine" Decode.int
+          StartCol = get.Required.Field "startCol" Decode.int
+          EndLine = get.Required.Field "endLine" Decode.int
+          EndCol = get.Required.Field "endCol" Decode.int })
+
+let private decoderASTErrorSeverity: Decoder<ASTErrorSeverity> =
+    Decode.string
+    |> Decode.map (fun s ->
+        match s with
+        | "error" -> ASTErrorSeverity.Error
+        | "warning" -> ASTErrorSeverity.Warning
+        | "info" -> ASTErrorSeverity.Info
+        | _ -> ASTErrorSeverity.Hidden)
+
+let private decodeASTError: Decoder<ASTError> =
+    Decode.object (fun get ->
+        { SubCategory = get.Required.Field "subCategory" Decode.string
+          Range = get.Required.Field "range" decodeRange
+          Severity = get.Required.Field "severity" decoderASTErrorSeverity
+          ErrorNumber = get.Required.Field "errorNumber" Decode.int
+          Message = get.Required.Field "message" Decode.string })
 
 let decodeFormatResponse: Decoder<FormatResponse> =
     Decode.object (fun get ->

--- a/src/client/fsharp/FantomasOnline/View.fs
+++ b/src/client/fsharp/FantomasOnline/View.fs
@@ -341,32 +341,32 @@ let settings isFsi model dispatch =
                     Placeholder "Filter settings"
                     OnChange(fun (ev: Browser.Types.Event) -> ev.Value |> UpdateSettingsFilter |> dispatch)
                 ]
-                div [
-                    ClassName "form-group"
-                ] [
-                      label [ ClassName "d-block" ] [
-                            strong [ ClassName "h4 text-center d-block mb-2" ] [ str "Upload .editorconfig" ]
-                        ]
-                      input [
-                          Type "file"
-                          Multiple false
-                          Accept ".editorconfig"
-                          OnInput (fun ev ->
-                                let file = ev.target?files?(0)
-                                let reader = Browser.Dom.FileReader.Create()
-                                reader.onload <- fun evt ->
+                div [ ClassName "form-group" ] [
+                    label [ ClassName "d-block" ] [
+                        strong [ ClassName "h4 text-center d-block mb-2" ] [ str "Upload .editorconfig" ]
+                    ]
+                    input [
+                        Type "file"
+                        Multiple false
+                        Accept ".editorconfig"
+                        OnInput(fun ev ->
+                            let file = ev.target?files?(0)
+                            let reader = Browser.Dom.FileReader.Create()
+
+                            reader.onload <-
+                                fun evt ->
                                     let fileContents: string = evt.target?result
-                                    let settings = Decoders.decodeOptionsFromEditorConfigFile model.UserOptions fileContents 
+
+                                    let settings =
+                                        Decoders.decodeOptionsFromEditorConfigFile model.UserOptions fileContents
+
                                     Fable.Core.JS.console.log $"%A{settings}"
-                                    settings
-                                    |> List.iter (fun setting -> dispatch (UpdateOption setting))
+                                    settings |> List.iter (fun setting -> dispatch (UpdateOption setting))
 
-                                reader.onerror <- fun evt ->
-                                    Fable.Core.JS.console.error $"%A{evt.target?result}"
+                            reader.onerror <- fun evt -> Fable.Core.JS.console.error $"%A{evt.target?result}"
 
-                                reader.readAsText(file)
-                              )
-                      ]
+                            reader.readAsText (file))
+                    ]
                 ]
             ]
 

--- a/src/client/fsharp/FantomasOnline/View.fs
+++ b/src/client/fsharp/FantomasOnline/View.fs
@@ -1,6 +1,8 @@
 module FantomasTools.Client.FantomasOnline.View
 
 open System.Text.RegularExpressions
+
+open Fable.Core.JsInterop
 open Fable.React
 open Fable.React.Props
 open FantomasOnline.Shared
@@ -338,6 +340,33 @@ let settings isFsi model dispatch =
                     DefaultValue model.SettingsFilter
                     Placeholder "Filter settings"
                     OnChange(fun (ev: Browser.Types.Event) -> ev.Value |> UpdateSettingsFilter |> dispatch)
+                ]
+                div [
+                    ClassName "form-group"
+                ] [
+                      label [ ClassName "d-block" ] [
+                            strong [ ClassName "h4 text-center d-block mb-2" ] [ str "Upload .editorconfig" ]
+                        ]
+                      input [
+                          Type "file"
+                          Multiple false
+                          Accept ".editorconfig"
+                          OnInput (fun ev ->
+                                let file = ev.target?files?(0)
+                                let reader = Browser.Dom.FileReader.Create()
+                                reader.onload <- fun evt ->
+                                    let fileContents: string = evt.target?result
+                                    let settings = Decoders.decodeOptionsFromEditorConfigFile model.UserOptions fileContents 
+                                    Fable.Core.JS.console.log $"%A{settings}"
+                                    settings
+                                    |> List.iter (fun setting -> dispatch (UpdateOption setting))
+
+                                reader.onerror <- fun evt ->
+                                    Fable.Core.JS.console.error $"%A{evt.target?result}"
+
+                                reader.readAsText(file)
+                              )
+                      ]
                 ]
             ]
 

--- a/src/client/fsharp/packages.lock.json
+++ b/src/client/fsharp/packages.lock.json
@@ -201,6 +201,59 @@
           "Fable.Browser.Dom": "2.4.4",
           "Fable.Core": "3.2.7"
         }
+      },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "1.1.1",
+        "contentHash": "TMBuzAHpTenGbGgk0SMTwyEkyijY/Eae4ZGsFNYJvAr/LDn1ku3Etp3FPxChmDp5HHF3kzJuoaa08N0xjqAJfQ=="
+      },
+      "Microsoft.NETCore.Targets": {
+        "type": "Transitive",
+        "resolved": "1.1.3",
+        "contentHash": "3Wrmi0kJDzClwAC+iBdUBpEKmEle8FQNsCs77fkiOIw/9oYA07bL1EZNX0kQ2OMN3xpwvl0vAtOCYY3ndDNlhQ=="
+      },
+      "System.Diagnostics.DiagnosticSource": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "9W0ewWDuAyDqS2PigdTxk6jDKonfgscY/hP8hm7VpxYhNHZHKvZTdRckberlFk3VnCmr3xBUyMBut12Q+T2aOw==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.5",
+        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
+      },
+      "System.Runtime": {
+        "type": "Transitive",
+        "resolved": "4.3.1",
+        "contentHash": "abhfv1dTK6NXOmu4bgHIONxHyEqFjW8HwXPmpY9gmll+ix9UNo4XDcmzJn6oLooftxNssVHdJC1pGT9jkSynQg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.1",
+          "Microsoft.NETCore.Targets": "1.1.3"
+        }
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "fantomas.core": {
+        "type": "Project",
+        "dependencies": {
+          "FSharp.Core": "[6.0.1, )",
+          "Fantomas.FCS": "[1.0.0, )"
+        }
+      },
+      "fantomas.fcs": {
+        "type": "Project",
+        "dependencies": {
+          "FSharp.Core": "[6.0.1, )",
+          "System.Diagnostics.DiagnosticSource": "[7.0.0, )",
+          "System.Memory": "[4.5.5, )",
+          "System.Runtime": "[4.3.1, )"
+        }
       }
     }
   }


### PR DESCRIPTION
This adds an input to try and load settings directly from an editorconfig file to simplify the repro process. Something is still off (I think it's related to the `order` param on the options) because it doesn't always load properly but it's close.