### PR TITLE
[Proposition] Allow user to reset setting to default values

### DIFF
--- a/src/client/fsharp/FantomasOnline/Model.fs
+++ b/src/client/fsharp/FantomasOnline/Model.fs
@@ -21,6 +21,7 @@ type Msg =
     | ChangeMode of FantomasMode
     | CopySettings
     | UpdateSettingsFilter of string
+    | ResetSettings
 
 [<RequireQualifiedAccess>]
 type FantomasTabState =

--- a/src/client/fsharp/FantomasOnline/State.fs
+++ b/src/client/fsharp/FantomasOnline/State.fs
@@ -196,6 +196,14 @@ let update isActiveTab (bubble: BubbleModel) msg model =
             UserOptions = userOptions
             State = FantomasTabState.OptionsLoaded },
         cmd
+
+    | ResetSettings ->
+        showSuccess "Settings reset to default values"
+
+        { model with
+            UserOptions = optionsListToMap model.DefaultOptions },
+        Cmd.none
+
     | Format ->
         let cmd =
             Cmd.batch

--- a/src/client/fsharp/FantomasOnline/View.fs
+++ b/src/client/fsharp/FantomasOnline/View.fs
@@ -341,6 +341,13 @@ let settings isFsi model dispatch =
                 ]
             ]
 
+        let resetSettings =
+            div [ ClassName Style.ResetSettings ] [
+                button [ ClassName Style.Secondary; OnClick(fun _ -> ResetSettings |> dispatch) ] [
+                    str "Reset settings"
+                ]
+            ]
+
         fragment [] [
             VersionBar.versionBar (sprintf "Version: %s" model.Version)
             fantomasMode
@@ -348,6 +355,12 @@ let settings isFsi model dispatch =
             hr []
             searchBox
             options
+            if userChangedSettings model then
+                hr []
+                resetSettings
+                // Needed for spacing at the bottom of the screen
+                // Could not find the correct CSS to do this
+                br []
         ]
 
 let idempotencyProblem =

--- a/src/client/fsharp/FantomasOnline/View.fs
+++ b/src/client/fsharp/FantomasOnline/View.fs
@@ -353,14 +353,11 @@ let settings isFsi model dispatch =
             fantomasMode
             fileExtension
             hr []
+            if userChangedSettings model then
+                resetSettings
+                hr []
             searchBox
             options
-            if userChangedSettings model then
-                hr []
-                resetSettings
-                // Needed for spacing at the bottom of the screen
-                // Could not find the correct CSS to do this
-                br []
         ]
 
 let idempotencyProblem =

--- a/src/client/src/styles/style.css
+++ b/src/client/src/styles/style.css
@@ -866,3 +866,11 @@ nav > div #docs-btn .long-text {
         color: var(--light);
     }
 }
+
+.reset-settings {
+    display: flex;
+}
+
+.reset-settings > button {
+    margin: auto;
+}

--- a/src/client/src/styles/style.css
+++ b/src/client/src/styles/style.css
@@ -787,6 +787,14 @@ nav > div #docs-btn .long-text {
     margin: 0;
 }
 
+.reset-settings {
+    display: flex;
+}
+
+.reset-settings > button {
+    margin: auto;
+}
+
 /* dark mode */
 @media (prefers-color-scheme: dark) {
     :root {
@@ -865,12 +873,4 @@ nav > div #docs-btn .long-text {
     #diagnostics li strong {
         color: var(--light);
     }
-}
-
-.reset-settings {
-    display: flex;
-}
-
-.reset-settings > button {
-    margin: auto;
 }


### PR DESCRIPTION
When reporting issues I always have a hard top finding the correct configuration because I never know which settings changed or not.

Adding this button allows the user to restore the default settings of Fantomas to start from a blank page